### PR TITLE
[Feature] Aceitar query string orderFormId no carregamento da tela de checkout

### DIFF
--- a/react/components/PaymentData.tsx
+++ b/react/components/PaymentData.tsx
@@ -29,14 +29,14 @@ export function PaymentData() {
   const filteredPaymentSystems = useMemo(
     () =>
       paymentSystems.filter(
-        (paymentSystem) => paymentSystem.groupName !== 'creditCardPaymentGroup'
+        (paymentSystem) => paymentSystem?.groupName !== 'creditCardPaymentGroup'
       ),
     [paymentSystems]
   )
 
   const options = filteredPaymentSystems.map((paymentSystem) => ({
-    value: paymentSystem.stringId,
-    label: paymentSystem.name,
+    value: paymentSystem?.stringId ?? '',
+    label: paymentSystem?.name ?? '',
   }))
 
   const [selectedPayment] = payments
@@ -88,7 +88,8 @@ export function PaymentData() {
   )
 
   const validPaymentSystem = filteredPaymentSystems.find(
-    (paymentSystem) => paymentSystem.stringId === selectedPayment?.paymentSystem
+    (paymentSystem) =>
+      paymentSystem?.stringId === selectedPayment?.paymentSystem
   )
 
   useEffect(() => {

--- a/react/hooks/useOrderFormCustom.ts
+++ b/react/hooks/useOrderFormCustom.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { OrderForm } from 'vtex.order-manager'
+import { useRuntime } from 'vtex.render-runtime'
 
 import { apiRequest } from '../services'
 import type { CompleteOrderForm, CompleteOrderFormData } from '../typings'
@@ -13,10 +14,17 @@ export type UseOrderFormReturn = {
 }
 
 export function useOrderFormCustom() {
+  const { query } = useRuntime()
+
+  const orderFormId = query?.orderFormId ?? ''
+
   const { data, isLoading } = useQuery<CompleteOrderFormData, Error>({
-    queryKey: ['invoiceData'],
+    queryKey: ['invoiceData', orderFormId],
     queryFn: () =>
-      apiRequest<CompleteOrderFormData>(`/api/checkout/pub/orderForm`, 'GET'),
+      apiRequest<CompleteOrderFormData>(
+        `/api/checkout/pub/orderForm/${orderFormId}`,
+        'GET'
+      ),
   })
 
   const {


### PR DESCRIPTION
#### What problem is this solving?

The customer must be able to pass as a parameter in the `/checkout-b2b` route or query param `orderFormId` and with this information, the cart must be updated with the data that was loaded from that ID that was passed.

#### How to test it?

In the `/checkout-b2b` route, pass an `orderFormId` as query params, example:
```
/checkout-b2b?orderFormId=6cd2e875658b45c48ee0d10d998f194a
```

[Workspace](https://icaroov--bravtexfashionb2b.myvtex.com/checkout-b2b?orderFormId=6cd2e875658b45c48ee0d10d998f194a)

#### Links/Docs
- https://developers.vtex.com/docs/api-reference/checkout-api#get-/api/checkout/pub/orderForm/-orderFormId-
