### PR TITLE
feat: dynamically change table schema for tax column

### DIFF
--- a/react/CheckoutB2B.tsx
+++ b/react/CheckoutB2B.tsx
@@ -295,7 +295,7 @@ function CheckoutB2B() {
 
             <div ref={tableRef}>
               <Table
-                key={`table-${
+                updateTableKey={`table-${
                   'tax' in schema.properties ? 'with-tax' : 'no-tax'
                 }`}
                 onRowClick={() => {}}

--- a/react/CheckoutB2B.tsx
+++ b/react/CheckoutB2B.tsx
@@ -295,6 +295,9 @@ function CheckoutB2B() {
 
             <div ref={tableRef}>
               <Table
+                key={`table-${
+                  'tax' in schema.properties ? 'with-tax' : 'no-tax'
+                }`}
                 onRowClick={() => {}}
                 loading={loading}
                 fullWidth

--- a/react/hooks/useTableSchema.tsx
+++ b/react/hooks/useTableSchema.tsx
@@ -68,6 +68,10 @@ export function useTableSchema(
     setSubtotal(totalValue)
   }, [orderForm.items, updatedPrices, setSubtotal, setListedPrice])
 
+  const hasTax = useMemo(() => {
+    return orderForm.items?.some((item) => !!item.tax) ?? false
+  }, [orderForm.items])
+
   return useMemo(
     () => ({
       properties: {
@@ -178,24 +182,26 @@ export function useTableSchema(
             return <QuantitySelector item={rowData} />
           },
         },
-        tax: {
-          width: 100,
-          title: formatMessage(messages.tax),
-          cellRenderer({ rowData }) {
-            return rowData.tax ? (
-              <TruncatedText
-                text={
-                  <FormattedPrice
-                    value={(rowData.tax * rowData.quantity) / 100}
-                  />
-                }
-                {...getStrike(rowData)}
-              />
-            ) : (
-              <>N/A</>
-            )
+        ...(hasTax && {
+          tax: {
+            width: 100,
+            title: formatMessage(messages.tax),
+            cellRenderer({ rowData }) {
+              return rowData.tax ? (
+                <TruncatedText
+                  text={
+                    <FormattedPrice
+                      value={(rowData.tax * rowData.quantity) / 100}
+                    />
+                  }
+                  {...getStrike(rowData)}
+                />
+              ) : (
+                <>N/A</>
+              )
+            },
           },
-        },
+        }),
         priceDefinition: {
           width: 120,
           title: formatMessage(messages.totalPrice),
@@ -247,6 +253,7 @@ export function useTableSchema(
       getDiscountedPrice,
       isSalesUser,
       handlesNewPrice,
+      hasTax,
     ]
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

This PR introduces a feature that dynamically hides or shows the `tax` column in the VTEX Styleguide `Table` component based on the presence of tax data in the order items.
When none of the items contain tax information, the `tax` column is omitted from the schema. When at least one item has tax, the column appears automatically.
To ensure proper re-rendering and layout recalculation by the Table component, a dynamic `key` is applied to the Table based on whether the column is present or not.

#### How to test it?

[Workspace](https://workspacename--bravtexfashionb2b.myvtex.com/checkout-b2b) -> ...bravtexfashionb2b.myvtex.com/checkout-b2b

- Add items with and without `tax` in the orderForm
- Observe that the `tax` column appears only when applicable
- Table layout remains consistent and well-aligned

#### Screenshots or example usage:

**Without tax column:**
![without](https://github.com/user-attachments/assets/44f24414-1888-495c-b103-6ee068d6d135)

`tax` not present in any item → column is hidden  

**With tax column:**
![with](https://github.com/user-attachments/assets/b76457eb-2d18-47f5-9d14-6569e1498a15)

At least one item has `tax` → column is shown  

#### Describe alternatives you've considered, if any.

- Tried using conditional schema updates without the dynamic key → Table did not recalculate column widths properly.

#### Related to / Depends on

#### How does this PR make you feel? [:link:](http://giphy.com/)
