### PR TITLE
feat: dynamically change table schema for margin column

### DIFF
--- a/react/hooks/useFetchPrices.ts
+++ b/react/hooks/useFetchPrices.ts
@@ -69,5 +69,10 @@ export function useTotalMargin() {
     [data, items]
   )
 
-  return totalMargin
+  const hasMargin = useMemo(
+    () => data?.some((item) => !!item.costPrice) ?? false,
+    [data]
+  )
+
+  return { totalMargin, hasMargin }
 }

--- a/react/hooks/useTableSchema.tsx
+++ b/react/hooks/useTableSchema.tsx
@@ -4,7 +4,7 @@ import { FormattedPrice } from 'vtex.formatted-price'
 import { OrderItems } from 'vtex.order-items'
 import { ButtonWithIcon, IconDelete, Tooltip } from 'vtex.styleguide'
 
-import { useOrderFormCustom, usePermissions } from '.'
+import { useOrderFormCustom, usePermissions, useTotalMargin } from '.'
 import { useCheckoutB2BContext } from '../CheckoutB2BContext'
 import ManualPrice from '../components/ManualPrice'
 import { MarginProductPrice } from '../components/MarginProductPrice'
@@ -24,6 +24,7 @@ export function useTableSchema(
   discount: number,
   onUpdatePrice: (id: string, newPrice: number) => void
 ): TableSchema<CustomItem> {
+  const { hasMargin } = useTotalMargin()
   const { orderForm } = useOrderFormCustom()
   const { formatMessage } = useIntl()
   const { removeItem } = useOrderItems()
@@ -154,27 +155,28 @@ export function useTableSchema(
             )
           },
         },
-        ...(isSalesUser && {
-          listPrice: {
-            width: 100,
-            title: formatMessage(messages.margin),
-            cellRenderer({ rowData }) {
-              const sellingPrice = getSellingPrice(rowData, discount)
+        ...(hasMargin &&
+          isSalesUser && {
+            listPrice: {
+              width: 100,
+              title: formatMessage(messages.margin),
+              cellRenderer({ rowData }) {
+                const sellingPrice = getSellingPrice(rowData, discount)
 
-              return (
-                <TruncatedText
-                  text={
-                    <MarginProductPrice
-                      itemId={rowData.id}
-                      sellingPrice={sellingPrice}
-                    />
-                  }
-                  {...getStrike(rowData)}
-                />
-              )
+                return (
+                  <TruncatedText
+                    text={
+                      <MarginProductPrice
+                        itemId={rowData.id}
+                        sellingPrice={sellingPrice}
+                      />
+                    }
+                    {...getStrike(rowData)}
+                  />
+                )
+              },
             },
-          },
-        }),
+          }),
         quantity: {
           width: 110,
           title: <div className="tc">{formatMessage(messages.quantity)}</div>,
@@ -251,8 +253,9 @@ export function useTableSchema(
       discount,
       getSellingPrice,
       getDiscountedPrice,
-      isSalesUser,
       handlesNewPrice,
+      isSalesUser,
+      hasMargin,
       hasTax,
     ]
   )

--- a/react/hooks/useTotalizers.tsx
+++ b/react/hooks/useTotalizers.tsx
@@ -25,7 +25,7 @@ export function useTotalizers() {
     [items]
   )
 
-  const totalMargin = useTotalMargin()
+  const { totalMargin } = useTotalMargin()
 
   const { data: taxes } = useTaxes()
 


### PR DESCRIPTION
#### What problem is this solving?

Hides the "Margin" column in the B2B Checkout item table when no items have a costPrice, ensuring that the column is only displayed when relevant.

- Reused the useTotalMargin hook to include a new flag: hasMargin. 
- Updated the useTableSchema hook to conditionally render the margin column based on the hasMargin flag. 
- Preserved the business rule that the margin column only appears for sales users and when at least one item has a costPrice.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://raabelo--bravtexfashionb2b.myvtex.com/checkout-b2b) --> bravtexfashionb2b.myvtex.com/checkout-b2b

#### Screenshots or example usage:

Will be added

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)
